### PR TITLE
Supports any package manager, fixes #7

### DIFF
--- a/create-bolt-uxp/src/build.ts
+++ b/create-bolt-uxp/src/build.ts
@@ -12,7 +12,7 @@ import {
   globalIncludes,
   hybridFiles,
 } from "./data";
-import { execAsync, posix } from "./utils";
+import { execAsync, getPackageManager, posix } from "./utils";
 import { spinner, note } from "@clack/prompts";
 
 import { capitalize, replace } from "radash";
@@ -245,11 +245,12 @@ export const buildBoltUXP = async (args: Args) => {
     .replace(/bolt\.uxp\.plugin/g, args.id);
   fs.writeFileSync(uxpConfig, uxpConfigData, "utf8");
 
+  const pm = getPackageManager() || "npm";
   // * Dependencies
   if (args.installDeps) {
     const s = spinner();
     s.start("Installing dependencies...");
-    await execAsync(`cd ${fullPath} && yarn`);
+    await execAsync(`cd ${fullPath} && ${pm} install`);
     s.stop("Dependencies installed!");
   }
 
@@ -275,7 +276,7 @@ export const buildBoltUXP = async (args: Args) => {
       ...summary,
       "",
       `Dependencies not installed. To install, run: ${color.yellow(
-        `cd ${path.basename(fullPath)} && yarn )`
+        `cd ${path.basename(fullPath)} && ${pm} install`
       )}`,
     ];
   }

--- a/create-bolt-uxp/src/utils.ts
+++ b/create-bolt-uxp/src/utils.ts
@@ -14,3 +14,18 @@ export const execAsync = (cmd: string) => {
     });
   });
 };
+
+/**
+ * Supports npm, pnpm, Yarn, cnpm, bun and any other package manager that sets the npm_config_user_agent env variable.
+ * Thanks to https://github.com/zkochan/packages/tree/main/which-pm-runs for this code!
+ */
+export function getPackageManager() {
+  if (!process.env.npm_config_user_agent) {
+    return undefined;
+  }
+  const userAgent = process.env.npm_config_user_agent;
+  const pmSpec = userAgent.split(" ")[0];
+  const separatorPos = pmSpec.lastIndexOf("/");
+  const name = pmSpec.substring(0, separatorPos);
+  return name === "npminstall" ? "cnpm" : name;
+}


### PR DESCRIPTION
Tested with `npm` and `pnmp`. Fixes #7 

Notes:
- `yarn.lock` is still included in the template regardless of the package manager used.
- the template's `package.json` still includes `yarn`