### PR TITLE
adjust build path resolution

### DIFF
--- a/create-bolt-uxp/src/build.ts
+++ b/create-bolt-uxp/src/build.ts
@@ -136,7 +136,7 @@ const formatFile = async (
 };
 
 export const buildBoltUXP = async (args: Args) => {
-  const fullPath = path.join(process.cwd(), args.folder);
+  const fullPath = path.resolve(args.folder);
   note(`Creating Bolt UXP in ${color.green(color.bold(fullPath))}`, "Info");
 
   const localStem = posix(

--- a/create-bolt-uxp/src/index.ts
+++ b/create-bolt-uxp/src/index.ts
@@ -58,7 +58,7 @@ export const main = async (params: OptionalArgs) => {
       // placeholder: 'Not sure',
       initialValue: "./",
       validate(value) {
-        if (value.length < 3) return `Value is required!`;
+        if (value.length < 1) return `Value is required!`;
       },
     })) as string;
     handleCancel(folder);


### PR DESCRIPTION
There were several issues related to paths not resolving properly when running create-bolt-uxp. I adjusted so it no longer concats the working directory on the path. The new path.resolve should work with relative and absolute paths.

Update: Added a fix which should allow using './' as the path. Currently it only allows paths of 3 chars or more. This will allow using the initial value (current directory) as a path. 

Fixes issues in #24 