### PR TITLE
Change `manifestVersion` from 6 to 5

### DIFF
--- a/uxp.config.ts
+++ b/uxp.config.ts
@@ -18,7 +18,7 @@ const manifest: UXP_Manifest = {
   name,
   version,
   main: "index.html",
-  manifestVersion: 6,
+  manifestVersion: 5,
   host: [
     // BOLT_PHXS_START
     {


### PR DESCRIPTION
`manifestVersion` is `6` for UXP https://github.com/hyperbrew/bolt-uxp/blob/master/uxp.config.ts#L21
Git blame found the commit https://github.com/hyperbrew/bolt-uxp/commit/ae93722652f599f7cfa437fbf08f8ad321c48691

`extensionManifestVersion` is `6.0` for CEP  https://github.com/hyperbrew/bolt-cep/blob/master/cep.config.ts#L12

This does not make sense to me as the latest manifest version for UXP should still be `5`. From what I understand the manifest versions for CEP and UXP  are not necessarily in sync and `6` does not exists yet for UXP though it looks like it's working for now. But might break later once introduced if it has breaking changes.

When searching for a `manifestVersion` for UXP, I can only find references about a version `5`, like:
- https://developer.adobe.com/indesign/uxp/plugins/concepts/manifest/
- https://www.davidebarranca.com/development/adobe-uxp-things-you-need-to-know-manifest-5
- https://developer.adobe.com/indesign/uxp/plugins/tutorials/inter-plugin-comm/
- https://adobedocs.github.io/uxp-photoshop/uxp-api/reference-js/Modules/uxp/Persistent%20File%20Storage/FileSystemProvider/

Also https://developer.adobe.com/photoshop/uxp/2022/guides/uxp_guide/uxp-misc/manifest-v5/ mentions
> Manifest v5 gives developers access to a new plugin permissions model and WebViews in modal dialogs. Using the full manifest v5 feature set requires PS 23.3.0 or higher. (UXP 6.0 or higher)

So maybe the confusion comes from the fact that the manifest version for CEP and the UXP version (not the manifest) also someone aligned at v6 for a while? (latest UXP version is `UXP v8.4.0` based on the https://developer.adobe.com/photoshop/uxp/2022/ps_reference/changelog/)

I wanted to point this out as it's confusing to find a `"manifestVersion" = 6` for UXP when there are no documentation for it.

From my tests, `"manifestVersion" = 5` has no impact on my plugin (which uses a local Webview (very recent feature), and also uses the FileSytem)