### PR TITLE
Refs #54

### DIFF
--- a/src/api/utils/premierepro-utils.ts
+++ b/src/api/utils/premierepro-utils.ts
@@ -1,4 +1,4 @@
-import { premierepro } from "../../globals";
+import { premierepro, uxp } from "../../globals";
 import {
   Action,
   AudioClipTrackItem,
@@ -10,44 +10,35 @@ import {
   Sequence,
   VideoClipTrackItem,
   VideoTrack,
+  ClipProjectItem,
+  FrameRate,
+  Metadata,
 } from "../../types/ppro";
 
-/** Easily run a transaction */
-export const asTransaction = async (
-  proj: Project,
-  actions: Action[],
-  description: string,
-) => {
-  proj.executeTransaction(async (compAction) => {
-    for (const action of actions) {
-      compAction.addAction(action);
-    }
-  }, description);
-};
+/**
+ * premierepro-utils
+ *
+ * NOTE: Requires Adobe Premiere Pro 26.3.0+ (Build 68 or newer).
+ * Earlier versions use a different transaction API, so utils that rely on
+ * transactions (cloneSequence, deleteItem, setPrMetadata, etc.) may not work in erlier versions
+ */
 
-/** Safely run a transaction by creating actions in-scope  */
-export const asTransactionSafe = async (
+/**
+ * Run a transaction inside a locked project access, creating actions in-scope.
+ *
+ * Since Premiere 26.3.0+ actions must be created inside the locked +
+ * transaction scope, not before. Pass action factories (`() => Action`)
+ * rather than pre-built actions
+ */
+export const lockedTransactionSafe = async (
   proj: Project,
   actions: Array<() => Action>,
-  description: string,
-) => {
-  return proj.executeTransaction(async (compAction) => {
-    for (const action of actions) {
-      compAction.addAction(action());
-    }
-  }, description);
-};
-
-/** Easily a transaction in a Locked Access */
-export const lockedTransaction = async (
-  proj: Project,
-  actions: Action[],
   description: string,
 ) => {
   proj.lockedAccess(() =>
     proj.executeTransaction(async (compAction) => {
       for (const action of actions) {
-        compAction.addAction(action);
+        compAction.addAction(action());
       }
     }, description),
   );
@@ -124,16 +115,16 @@ export const forEachClip = async (
   }
 };
 
-/** Clone sequence and returne the cloned instance */
+/** Clone sequence and return the cloned instance */
 export const cloneSequence = async (
   project: Project,
   sequence: Sequence,
   name: string,
 ) => {
   const existingIds = (await project.getSequences()).map((s) => s.guid);
-  await asTransaction(
+  await lockedTransactionSafe(
     project,
-    [sequence.createCloneAction()],
+    [() => sequence.createCloneAction()],
     "Clone Sequence",
   );
   const clonedSequence = (await project.getSequences()).find(
@@ -141,9 +132,9 @@ export const cloneSequence = async (
   );
   if (clonedSequence) {
     const clonedProjItem = await clonedSequence.getProjectItem();
-    await asTransaction(
+    await lockedTransactionSafe(
       project,
-      [clonedProjItem.createSetNameAction(name)],
+      [() => clonedProjItem.createSetNameAction(name)],
       "Rename Cloned Sequence",
     );
   } else {
@@ -183,60 +174,6 @@ export const forEachDescendant = async (
     } else {
       await callback(child, depth);
     }
-  }
-};
-
-//TODO: test with edge cases and different item types
-/** Delete a project item (bin, sequence, clip) */
-export const deleteItem = async (item: ProjectItem) => {
-  const parent = item.getParentBin();
-  if (!parent) return; // rootItem or detached - nothing valid to delete
-  const proj = await item.getProject();
-  await asTransaction(
-    proj,
-    [parent.createRemoveItemAction(item)],
-    "Delete Item",
-  );
-};
-
-//REMOVE OR FINISH
-//TODO: REVISIT. Implement more optimised approach. Test edge cases - stale items, parents removals, offline files, different projects, different types
-/** Safely delete several project items in a single undo step.
- * Multi-project aware: groups by owning project, one transaction per project.
- * Parent/child optimization: if an ancestor is also being deleted, the descendant
- * is skipped - removing the ancestor takes its contents with it*/
-export const deleteItems = async (items: ProjectItem[]) => {
-  const ids = new Set(items.map((i) => i.getId()));
-  const byProject = new Map<string, { proj: Project; actions: Action[] }>();
-
-  for (const item of items) {
-    const parent = item.getParentBin();
-    if (!parent) continue;
-
-    // skip if any ancestor is also in the set
-    let p: FolderItem | null = parent;
-    let coveredByAncestor = false;
-    while (p) {
-      //TODO: remake or add inf loop stopped to avoid freezing for unexpcted 'while' cases
-      const asItem = premierepro.ProjectItem.cast(p);
-      if (!asItem) break;
-      if (ids.has(asItem.getId())) {
-        coveredByAncestor = true;
-        break;
-      }
-      p = asItem.getParentBin();
-    }
-    if (coveredByAncestor) continue;
-
-    const proj = await item.getProject();
-    const key = proj.guid?.toString?.() ?? String(proj);
-    let bucket = byProject.get(key);
-    if (!bucket) byProject.set(key, (bucket = { proj, actions: [] }));
-    bucket.actions.push(parent.createRemoveItemAction(item));
-  }
-
-  for (const { proj, actions } of byProject.values()) {
-    if (actions.length) await asTransaction(proj, actions, "Delete Items");
   }
 };
 
@@ -302,6 +239,24 @@ export const getChildByName = async (
       (norm ? norm(child.name) : child.name) === target &&
       (type === undefined || child.type === type),
   );
+};
+
+/**
+ * Find the first ClipProjectItem under `parent` whose media file path
+ * equals `path`. Recurses into sub-bins
+ */
+export const findItemByPath = async (
+  parent: ProjectItem | FolderItem,
+  path: string,
+): Promise<ClipProjectItem | undefined> => {
+  const folder = premierepro.FolderItem.cast(parent as ProjectItem);
+  if (!folder) return;
+  for (const child of await folder.getItems()) {
+    const clip = premierepro.ClipProjectItem.cast(child);
+    if (clip && (await clip.getMediaFilePath()) === path) return clip;
+    const found = await findItemByPath(child, path);
+    if (found) return found;
+  }
 };
 
 /** Find a direct child of a bin/root by id.*/
@@ -380,6 +335,18 @@ export const getItemByNameChain = async (
   return currentItem as ProjectItem | undefined;
 };
 
+/** Delete a project item (bin, sequence, clip) */
+export const deleteItem = async (item: ProjectItem) => {
+  const parent = item.getParentBin();
+  if (!parent) return; // rootItem or detached - nothing valid to delete
+  const proj = await item.getProject();
+  await lockedTransactionSafe(
+    proj,
+    [() => parent.createRemoveItemAction(item)],
+    "Delete Item",
+  );
+};
+
 /** Get sequence from project item*/
 export const itemToSequence = async (
   item: ProjectItem,
@@ -393,7 +360,7 @@ export const itemToSequence = async (
 /** Get a project item's duration.
  *
  * Synthetic items (adjustment layers, Color Matte, etc.) always return a
- * `TickTime` of 43200s
+ * `TickTime` of 43200s.
  */
 export const getItemDuration = async (
   item: ProjectItem,
@@ -408,7 +375,7 @@ export const getItemDuration = async (
 
   const media = await clipItem.getMedia();
   if (!media) return;
-  const dur = await media.duration;
+  const dur = media.duration;
   return dur;
 };
 
@@ -441,6 +408,62 @@ export const getFrameRate = async (
   const fps = fi?.getFrameRate();
   return fps ? premierepro.FrameRate.createWithValue(fps) : undefined;
 };
+
+//Metadata helpers
+const PPRO_META_URI = "http://ns.adobe.com/premierePrivateProjectMetaData/1.0/";
+
+/**
+ * Read Premiere project metadata fields off a ProjectItem. Missing fields are omitted from
+ *
+ * To discover available fields on an item use `listPrMetadataKeys(item)`
+ *
+ * @example await getPrMetadata(item, ["Column.Intrinsic.Name", "Column.Intrinsic.MediaType"])
+ */
+export const getPrMetadata = async (
+  projectItem: ProjectItem,
+  fields: string[],
+): Promise<Record<string, string>> => {
+  //@ts-ignore
+  const { XMPMeta } = uxp.xmp;
+  const xmpStr = await premierepro.Metadata.getProjectMetadata(projectItem);
+  const xmp = new XMPMeta(xmpStr);
+  const result: { [key: string]: string } = {};
+
+  for (const f of fields) {
+    if (xmp.doesPropertyExist(PPRO_META_URI, f)) {
+      result[f] = xmp.getProperty(PPRO_META_URI, f).value;
+    }
+  }
+  return result;
+};
+
+/**
+ * Discover field names on a ProjectItem's project metadata.
+ * Returns the local field names that can be fed back into `getPrMetadata`.
+ */
+export const listPrMetadataKeys = async (
+  projectItem: ProjectItem,
+): Promise<string[]> => {
+  //@ts-ignore
+  const { XMPMeta, XMPConst } = uxp.xmp;
+  const xmp = new XMPMeta(
+    await premierepro.Metadata.getProjectMetadata(projectItem),
+  );
+  const it = xmp.iterator(XMPConst.ITERATOR_JUST_CHILDREN, PPRO_META_URI, "");
+
+  const keys: string[] = [];
+  let n: any;
+  while ((n = it.next())) {
+    if (!n.path) continue;
+    if (n.path.includes("/")) continue; // skip nested struct internals
+    keys.push(n.path.replace(/^premierePrivateProjectMetaData:/, ""));
+  }
+  return keys;
+};
+
+//todo
+// setPrMetadata
+// removePrMetadata
 
 // Audio Conversions
 

--- a/src/api/utils/premierepro-utils.ts
+++ b/src/api/utils/premierepro-utils.ts
@@ -2,7 +2,9 @@ import { premierepro } from "../../globals";
 import {
   Action,
   AudioTrack,
+  FolderItem,
   Project,
+  ProjectItem,
   Sequence,
   VideoTrack,
 } from "../../types/ppro";
@@ -115,3 +117,81 @@ export const cloneSequence = async (
   }
   return clonedSequence;
 };
+
+/** Loop over each direct child of a bin */
+export const forEachChild = async (
+  item: ProjectItem | FolderItem,
+  callback: (child: ProjectItem, index: number) => void | Promise<void>,
+) => {
+  const folder = premierepro.FolderItem.cast(item as ProjectItem);
+
+  if (!folder) return; // not a bin, nothing to iterate
+  const items = await folder.getItems();
+  for (let i = 0; i < items.length; i++) {
+    await callback(items[i], i);
+  }
+};
+
+/** Loop over each item inside a bin and all its sub-bins */
+export const forEachDescendant = async (
+  item: ProjectItem | FolderItem,
+  callback: (child: ProjectItem, depth: number) => void | Promise<void>,
+  depth = 0,
+) => {
+  const folder = premierepro.FolderItem.cast(item as ProjectItem);
+  if (!folder) return;
+  const items = await folder.getItems();
+  for (const child of items) {
+    await callback(child, depth);
+    await forEachDescendant(child, callback, depth + 1);
+  }
+};
+
+//TODO: TEST EDGE CASES AND PROJECT ITEM TYPES
+/** Delete a project item (bin, sequence, clip) */
+export const deleteItem = async (item: ProjectItem) => {
+  const parent = item.getParentBin();
+  if (!parent) return; // rootItem or detached - nothing valid to delete
+  const proj = await item.getProject();
+  await asTransaction(
+    proj,
+    [parent.createRemoveItemAction(item)],
+    "Delete Item",
+  );
+};
+
+//TODO: TEST EDGE CASES + PROJECT SWITCHES
+/** Delete many project items in a single undo step (per project) */
+export const deleteItems = async (items: ProjectItem[]) => {
+  // Group items by their owning project so cross-project arrays still work
+  const byProject = new Map<string, { proj: Project; actions: Action[] }>();
+
+  for (const item of items) {
+    const parent = item.getParentBin();
+    if (!parent) continue; // rootItem or detached - skip
+    const proj = await item.getProject();
+    const key = proj.guid?.toString?.() ?? String(proj);
+    let bucket = byProject.get(key);
+    if (!bucket) {
+      bucket = { proj, actions: [] };
+      byProject.set(key, bucket);
+    }
+    bucket.actions.push(parent.createRemoveItemAction(item));
+  }
+
+  for (const { proj, actions } of byProject.values()) {
+    if (actions.length === 0) continue;
+    await asTransaction(proj, actions, "Delete Items");
+  }
+};
+
+// /**
+// ![](data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSc3OTYnIGhlaWdodD0nMjAnPjx0ZXh0IHg9JzYnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzdBNUZGRic+VmlvbGV0PC90ZXh0Pjx0ZXh0IHg9JzU4JyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyMzRjdFOEUnPklyaXM8L3RleHQ+PHRleHQgeD0nOTYnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzREOEEzRSc+Q2FyaWJiZWFuPC90ZXh0Pjx0ZXh0IHg9JzE2OScgeT0nMTQnIGZvbnQtZmFtaWx5PSdtb25vc3BhY2UnIGZvbnQtc2l6ZT0nMTInIGZvbnQtd2VpZ2h0PSdib2xkJyBmaWxsPScjQTg2NEE4Jz5MYXZlbmRlcjwvdGV4dD48dGV4dCB4PScyMzUnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzNFN0U5Nyc+Q2VydWxlYW48L3RleHQ+PHRleHQgeD0nMzAxJyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyM1QzZFMkUnPkZvcmVzdDwvdGV4dD48dGV4dCB4PSczNTMnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0IzM0E0Ric+Um9zZTwvdGV4dD48dGV4dCB4PSczOTEnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0MzNkIyQSc+TWFuZ288L3RleHQ+PHRleHQgeD0nNDM2JyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyM1QzJFQUEnPlB1cnBsZTwvdGV4dD48dGV4dCB4PSc0ODgnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzJFNEZBQSc+Qmx1ZTwvdGV4dD48dGV4dCB4PSc1MjYnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzNFOEE4QSc+VGVhbDwvdGV4dD48dGV4dCB4PSc1NjQnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0EwMzU2QSc+TWFnZW50YTwvdGV4dD48dGV4dCB4PSc2MjMnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0E4OTY3OCc+VGFuPC90ZXh0Pjx0ZXh0IHg9JzY1NCcgeT0nMTQnIGZvbnQtZmFtaWx5PSdtb25vc3BhY2UnIGZvbnQtc2l6ZT0nMTInIGZvbnQtd2VpZ2h0PSdib2xkJyBmaWxsPScjM0U4QTRGJz5HcmVlbjwvdGV4dD48dGV4dCB4PSc2OTknIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzdBNEYyRSc+QnJvd248L3RleHQ+PHRleHQgeD0nNzQ0JyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyNCM0EwM0UnPlllbGxvdzwvdGV4dD48L3N2Zz4=)*/
+
+// Audio Conversions
+
+/** Convert dB to a linear decimal gain value */
+export const dbToDec = (x: number) => Math.pow(10, (x - 15) / 20);
+
+/** Convert a linear decimal gain value to dB */
+export const decToDb = (x: number) => 20 * Math.log(x) * Math.LOG10E + 15;

--- a/src/api/utils/premierepro-utils.ts
+++ b/src/api/utils/premierepro-utils.ts
@@ -393,7 +393,7 @@ export const itemToSequence = async (
 /** Get a project item's duration.
  *
  * Synthetic items (adjustment layers, Color Matte, etc.) always return a
- * `TickTime` of 43200s.
+ * `TickTime` of 43200s
  */
 export const getItemDuration = async (
   item: ProjectItem,
@@ -410,6 +410,36 @@ export const getItemDuration = async (
   if (!media) return;
   const dur = await media.duration;
   return dur;
+};
+
+/** Get an item's video frame rate.
+ *
+ * For synthetic items (adjustment layers, color matte, etc.) this exposes
+ * the frame rate set at creation - the Metadata panel doesn't have this info
+ *
+ * Audio-only items return undefined
+ */
+export const getFrameRate = async (
+  item: ProjectItem | ClipProjectItem | Sequence,
+): Promise<FrameRate | undefined> => {
+  //duck check if item is Sequence
+  if ("getVideoTrack" in item) {
+    return (await item.getSettings()).getVideoFrameRate();
+  }
+
+  //duck check if item is Clip, otherwise cast to it
+  const clipItem =
+    "getMedia" in item ? item : premierepro.ClipProjectItem.cast(item);
+  if (!clipItem) return;
+
+  //if sequence was passed as a project item, do recursive call
+  if (await clipItem.isSequence()) {
+    return getFrameRate(await clipItem.getSequence());
+  }
+
+  const fi = await clipItem.getFootageInterpretation();
+  const fps = fi?.getFrameRate();
+  return fps ? premierepro.FrameRate.createWithValue(fps) : undefined;
 };
 
 // Audio Conversions

--- a/src/api/utils/premierepro-utils.ts
+++ b/src/api/utils/premierepro-utils.ts
@@ -45,7 +45,6 @@ export const lockedTransactionSafe = async (
   );
 };
 
-//TODO: check for potential bugs - in extendscript were cases tracks indices don't match UI order
 /** Loop over each audio track */
 export const forEachAudioTrack = async (
   sequence: Sequence,
@@ -66,7 +65,6 @@ export const forEachAudioTrack = async (
   }
 };
 
-//TODO: check for potential bugs - in extendscript were cases tracks indices don't match UI order
 /** Loop over each video track */
 export const forEachVideoTrack = async (
   sequence: Sequence,
@@ -158,7 +156,6 @@ export const forEachChild = async (
   }
 };
 
-//TODO: edge tests. Test cases where callback modifies some descendants
 /** Loop over each item inside a bin and all its sub-bins.  */
 export const forEachDescendant = async (
   item: ProjectItem | FolderItem,
@@ -201,7 +198,6 @@ export const resolveOrActiveRoot = async (
 ): Promise<FolderItem | undefined> =>
   (await resolveToFolderItem(item)) ?? (await getActiveRoot());
 
-//TODO? extend or create separate function to abstract futher with friendlier types — e.g. SEQUENCE, MULTICAM_SOURCE, SUBCLIP, NEST, AUDIO, MEDIA, MOGRT
 /** Find a direct child of a bin/root by name.
  *
  * Optionally filter by item type. Optionally compare case-insensitively and/or space-insensitively.
@@ -516,9 +512,9 @@ export const getSequenceLengthInFrames = async (
 const PPRO_META_URI = "http://ns.adobe.com/premierePrivateProjectMetaData/1.0/";
 
 /**
- * Read Premiere project metadata fields off a ProjectItem. Missing fields are omitted from
+ * Read metadata fields off a ProjectItem. Missing or empty fields are omitted
  *
- * To discover available fields on an item use `listPrMetadataKeys(item)`
+ * To discover available fields on an item use `listPrMetadataIds` or `findColumnIdByName`
  *
  * @example await getPrMetadata(item, ["Column.Intrinsic.Name", "Column.Intrinsic.MediaType"])
  */
@@ -532,19 +528,19 @@ export const getPrMetadata = async (
   const xmp = new XMPMeta(xmpStr);
   const result: { [key: string]: string } = {};
 
-  for (const f of fields) {
-    if (xmp.doesPropertyExist(PPRO_META_URI, f)) {
-      result[f] = xmp.getProperty(PPRO_META_URI, f).value;
+  for (const field of fields) {
+    if (xmp.doesPropertyExist(PPRO_META_URI, field)) {
+      result[field] = xmp.getProperty(PPRO_META_URI, field).value;
     }
   }
   return result;
 };
 
 /**
- * Discover field names on a ProjectItem's project metadata.
+ * Helpter function to discover field names on a ProjectItem's project metadata.
  * Returns the local field names that can be fed back into `getPrMetadata`.
  */
-export const listPrMetadataKeys = async (
+export const listPrMetadataIds = async (
   projectItem: ProjectItem,
 ): Promise<string[]> => {
   //@ts-ignore
@@ -562,6 +558,155 @@ export const listPrMetadataKeys = async (
     keys.push(n.path.replace(/^premierePrivateProjectMetaData:/, ""));
   }
   return keys;
+};
+
+type PrMetaField =
+  | { name: string; id?: string; value: string; type?: "text" }
+  | { name: string; id?: string; value: number; type: "integer" | "real" }
+  | { name: string; id?: string; value: boolean; type: "boolean" };
+
+/**
+ * Set metadata fields on a ProjectItem. Update existing
+ * columns (e.g. `Column.PropertyText.Name`) or add new (e.g. `HyperbrewPlugin.Notes`)
+ *
+ * For built-in fields you must pass the real internal ColumnID — use
+ * `findColumnIdByName(item, "Description")` to look one up by display name
+ */
+export const setPrMetadata = async (
+  projectItem: ProjectItem,
+  fields: PrMetaField[],
+): Promise<void> => {
+  //@ts-ignore
+  const { XMPMeta } = uxp.xmp;
+  const project = await projectItem.getProject();
+
+  const xmp = new XMPMeta(
+    await premierepro.Metadata.getProjectMetadata(projectItem),
+  );
+  const updated: string[] = [];
+
+  for (const field of fields) {
+    const type = field.type ?? "text";
+
+    const typeCode = (premierepro.Metadata as any)[
+      `METADATA_TYPE_${type.toUpperCase()}` //get static numeric metadata type code
+    ];
+
+    //Ensure field is registered, returns false if already exists on schema
+    await premierepro.Metadata.addPropertyToProjectMetadataSchema(
+      field.name,
+      field.id ?? field.name,
+      typeCode,
+    );
+
+    // Booleans must be capitalized "True"/"False"; everything else stringifies fine
+    const value =
+      type === "boolean"
+        ? field.value
+          ? "True"
+          : "False"
+        : String(field.value);
+    xmp.setProperty(PPRO_META_URI, field.name, value);
+    updated.push(field.name);
+  }
+
+  await lockedTransactionSafe(
+    project,
+    [
+      () =>
+        premierepro.Metadata.createSetProjectMetadataAction(
+          projectItem,
+          xmp.serialize(),
+          updated,
+        ),
+    ],
+    "Set Project Metadata",
+  );
+};
+
+/** Field reference for `removePrMetadata`.
+ *
+ * Pass a bare string for text fields (full delete), or `{ name, type }` for
+ * typed fields so the function can reset them to a clean default
+ */
+type PrMetaRemoveField =
+  | string
+  | { name: string; type: "text" | "integer" | "real" | "boolean" };
+
+/**
+ * Remove or clear Premiere project metadata fields on a ProjectItem
+ *
+ * **Behavior depends on field type:**
+ * - **Text** fields are deleted from the XMP
+ * - **Bool/Int/Real** fields cannot be deleted - Premiere's schema layer
+ *   re-inserts a value. To avoid that the function
+ *   overwrite with a default (`False`/`0`/`0.000000`) so
+ *   the panel shows a sane empty state
+ *
+ * Note: this doesn't unregister the field from the project schema -
+ * the column will still appear in the Project panel's column
+ *
+ * @example
+ * await removePrMetadata(item, [
+ *   "Hyperbrew.SomeText",                           // string → text delete
+ *   { name: "Hyperbrew.SomeBool", type: "boolean" } // → reset to "False"
+ * ])
+ */
+export const removePrMetadata = async (
+  projectItem: ProjectItem,
+  fields: PrMetaRemoveField[],
+): Promise<void> => {
+  //@ts-ignore
+  const { XMPMeta } = uxp.xmp;
+  const project = await projectItem.getProject();
+  const xmp = new XMPMeta(
+    await premierepro.Metadata.getProjectMetadata(projectItem),
+  );
+
+  const touched: string[] = [];
+  for (const field of fields) {
+    const name = typeof field === "string" ? field : field.name;
+    const type = typeof field === "string" ? "text" : field.type;
+
+    if (!xmp.doesPropertyExist(PPRO_META_URI, name)) continue;
+
+    if (type === "text") {
+      // Text type field- fully delete from XMP
+      xmp.deleteProperty(PPRO_META_URI, name);
+    } else {
+      // custom set typed field - reset to default, otherwise Premiere always re-inserts a magic number
+      const defaultValue =
+        type === "boolean" ? "False" : type === "integer" ? "0" : "0.000000";
+      xmp.setProperty(PPRO_META_URI, name, defaultValue);
+    }
+    touched.push(name);
+  }
+
+  if (!touched.length) return;
+
+  await lockedTransactionSafe(
+    project,
+    [
+      () =>
+        premierepro.Metadata.createSetProjectMetadataAction(
+          projectItem,
+          xmp.serialize(),
+          touched,
+        ),
+    ],
+    "Remove Project Metadata",
+  );
+};
+
+/** Find a registered column's internal ID by its display name (e.g. "Description"). */
+export const findColumnIdByName = async (
+  item: ProjectItem,
+  displayName: string,
+): Promise<string | undefined> => {
+  const cols: { ColumnID: string; ColumnName: string }[] = JSON.parse(
+    await premierepro.Metadata.getProjectColumnsMetadata(item),
+  );
+  return cols.find((c) => c.ColumnName === displayName)?.ColumnID;
 };
 
 // Audio Conversions

--- a/src/api/utils/premierepro-utils.ts
+++ b/src/api/utils/premierepro-utils.ts
@@ -380,6 +380,16 @@ export const getItemByNameChain = async (
   return currentItem as ProjectItem | undefined;
 };
 
+/** Get sequence from project item*/
+export const itemToSequence = async (
+  item: ProjectItem,
+): Promise<Sequence | undefined> => {
+  const clipItem = premierepro.ClipProjectItem.cast(item);
+  if (!clipItem) return;
+  if (!(await clipItem.isSequence())) return;
+  return clipItem.getSequence();
+};
+
 // Audio Conversions
 
 /** Convert dB to a linear decimal gain value */

--- a/src/api/utils/premierepro-utils.ts
+++ b/src/api/utils/premierepro-utils.ts
@@ -92,7 +92,7 @@ export const forEachVideoTrack = async (
   }
 };
 
-/** Clone sequence and returned the cloned instance */
+/** Clone sequence and returne the cloned instance */
 export const cloneSequence = async (
   project: Project,
   sequence: Sequence,
@@ -133,8 +133,6 @@ export const forEachChild = async (
     await callback(items[i], i);
   }
 };
-
-//TODO: add throw guards
 
 //TODO: edge tests. Test cases where callback modifies some descendants
 /** Loop over each item inside a bin and all its sub-bins.  */
@@ -209,32 +207,58 @@ export const deleteItems = async (items: ProjectItem[]) => {
   }
 };
 
+/** Resolve passed item as a searchable FolderItem. */
+export const resolveToFolderItem = async (
+  item?: ProjectItem | FolderItem | Project,
+): Promise<FolderItem | undefined> => {
+  if (!item) return;
+  if ("getRootItem" in item) return item.getRootItem(); // only Project has "getRootItem"
+
+  // cast returns null if ProjectItem is not a bin type
+  return premierepro.FolderItem.cast(item as ProjectItem) ?? undefined;
+};
+
+/** Get the active project's rootItem. */
+export const getActiveRoot = async (): Promise<FolderItem | undefined> => {
+  const proj = await premierepro.Project.getActiveProject();
+  return proj ? proj.getRootItem() : undefined;
+};
+
+/** Resolve to a FolderItem, falling back to the active project's rootItem. */
+export const resolveOrActiveRoot = async (
+  item?: ProjectItem | FolderItem | Project,
+): Promise<FolderItem | undefined> =>
+  (await resolveToFolderItem(item)) ?? (await getActiveRoot());
+
 //TODO? extend or create separate function to abstract futher with friendlier types — e.g. SEQUENCE, MULTICAM_SOURCE, SUBCLIP, NEST, AUDIO, MEDIA, MOGRT
-/** Find a direct child of a bin or rootItem by name.
+/** Find a direct child of a bin/root by name.
+ *
  * Optionally filter by item type. Optionally compare case-insensitively and/or space-insensitively.
- * **NOTE:** sequences, nests, subclips and multicam sources are all type of CLIP. Type ROOT is excluded since it never appears as a child.
+ *
+ * **NOTE:** sequences, nests, subclips and multicam sources are all type of CLIP.
+ * Type ROOT is excluded since it never appears as a child
  */
 export const getChildByName = async (
-  item: ProjectItem | FolderItem,
   name: string,
+  parent: ProjectItem | FolderItem | Project,
   caseInsensitive?: boolean,
   spaceInsensitive?: boolean,
   projectItemType?: "CLIP" | "BIN" | "COMPOUND" | "FILE" | "STYLE",
 ): Promise<ProjectItem | undefined> => {
-  const folder = premierepro.FolderItem.cast(item as ProjectItem);
+  const folder = await resolveToFolderItem(parent);
   if (!folder) return;
 
   const type = projectItemType
-    ? premierepro.ProjectItem[`TYPE_${projectItemType}`]
+    ? premierepro.ProjectItem[`TYPE_${projectItemType}`] //look up the numeric type
     : undefined;
 
   const needNormalize = caseInsensitive || spaceInsensitive;
   const norm = needNormalize
-    ? (name: string) => {
-        let outName = name;
-        if (caseInsensitive) outName = outName.toLowerCase();
-        if (spaceInsensitive) outName = outName.replace(/\s+/g, "");
-        return outName;
+    ? (str: string) => {
+        let out = str;
+        if (caseInsensitive) out = out.toLowerCase();
+        if (spaceInsensitive) out = out.replace(/\s+/g, "");
+        return out;
       }
     : null;
   const target = norm ? norm(name) : name;
@@ -247,23 +271,23 @@ export const getChildByName = async (
   );
 };
 
-/** Find a direct child of a bin or rootItem by id. */
+/** Find a direct child of a bin/root by id.*/
 export const getChildById = async (
   id: string,
-  item: ProjectItem | FolderItem,
+  parent: ProjectItem | FolderItem | Project,
 ): Promise<ProjectItem | undefined> => {
-  const folder = premierepro.FolderItem.cast(item as ProjectItem);
+  const folder = await resolveToFolderItem(parent);
   if (!folder) return;
   const items = await folder.getItems();
   return items.find((child) => child.getId() === id);
 };
 
-/** Recursively find a descendant of a bin or rootItem by id. */
+/** Recursively find a descendant of a bin/root by id. */
 export const getDescendantById = async (
   id: string,
-  item: ProjectItem | FolderItem,
+  parent: ProjectItem | FolderItem | Project,
 ): Promise<ProjectItem | undefined> => {
-  const folder = premierepro.FolderItem.cast(item as ProjectItem);
+  const folder = await resolveToFolderItem(parent);
   if (!folder) return;
 
   const items = await folder.getItems();
@@ -279,21 +303,48 @@ export const getDescendantById = async (
 };
 
 /** Recursively find an item by id.
- * Optionally set `startFrom` to a Project or bin to scope. Defaults to active project. */
+ *
+ * Optionally set `parent` to a Project or bin to scope. Defaults to active project. */
 export const getItemById = async (
   id: string,
-  startFrom?: ProjectItem | FolderItem | Project,
+  parent?: ProjectItem | FolderItem | Project,
 ): Promise<ProjectItem | undefined> => {
-  // distinguish Project from bin by `getRootItem` property
-  if (startFrom && "getRootItem" in startFrom) {
-    const root = await startFrom.getRootItem();
-    return getDescendantById(id, root);
+  const root = await resolveOrActiveRoot(parent);
+  if (!root) return;
+
+  const findIn = async (
+    folder: FolderItem,
+  ): Promise<ProjectItem | undefined> => {
+    for (const child of await folder.getItems()) {
+      if (child.getId() === id) return child;
+      const childFolder = premierepro.FolderItem.cast(child);
+      if (childFolder) {
+        const found = await findIn(childFolder);
+        if (found) return found;
+      }
+    }
+  };
+
+  return findIn(root);
+};
+
+/** Find an item by combining a chain of bin names down the project tree.
+ *
+ * @example getItemByNameChain(["Assets", "Graphics", "logo.png"]);
+ *
+ * Optionally pass parent item to scope. Defaults to active project. */
+export const getItemByNameChain = async (
+  names: string[],
+  parent?: ProjectItem | FolderItem | Project,
+): Promise<ProjectItem | undefined> => {
+  let currentItem: ProjectItem | FolderItem | Project | undefined =
+    parent ?? (await getActiveRoot());
+
+  for (const name of names) {
+    if (!currentItem) return;
+    currentItem = await getChildByName(name, currentItem);
   }
-  if (startFrom) return getDescendantById(id, startFrom);
-  const proj = await premierepro.Project.getActiveProject();
-  if (!proj) return;
-  const root = await proj.getRootItem();
-  return getDescendantById(id, root);
+  return currentItem as ProjectItem | undefined;
 };
 
 // Audio Conversions

--- a/src/api/utils/premierepro-utils.ts
+++ b/src/api/utils/premierepro-utils.ts
@@ -1,11 +1,14 @@
 import { premierepro } from "../../globals";
 import {
   Action,
+  AudioClipTrackItem,
   AudioTrack,
+  Constants,
   FolderItem,
   Project,
   ProjectItem,
   Sequence,
+  VideoClipTrackItem,
   VideoTrack,
 } from "../../types/ppro";
 
@@ -92,6 +95,35 @@ export const forEachVideoTrack = async (
   }
 };
 
+/**
+ * Loop over each clip on a track.
+ *
+ * Optionally set `includeEmpty` to true to also visit empty clips
+ * (the gaps in between and after clips). Empty clips are null
+ *
+ * Optionally set `reverse` to true to loop from the last clip
+ */
+export const forEachClip = async (
+  track: VideoTrack | AudioTrack,
+  callback: (
+    clip: VideoClipTrackItem | AudioClipTrackItem | null,
+    index: number,
+  ) => void | Promise<void>,
+  includeEmpty = false,
+  reverse?: boolean,
+) => {
+  const clips = track.getTrackItems(1, includeEmpty); // 1 = CLIP
+  if (reverse) {
+    for (let i = clips.length - 1; i > -1; i--) {
+      await callback(clips[i], i);
+    }
+  } else {
+    for (let i = 0; i < clips.length; i++) {
+      await callback(clips[i], i);
+    }
+  }
+};
+
 /** Clone sequence and returne the cloned instance */
 export const cloneSequence = async (
   project: Project,
@@ -167,6 +199,7 @@ export const deleteItem = async (item: ProjectItem) => {
   );
 };
 
+//REMOVE OR FINISH
 //TODO: REVISIT. Implement more optimised approach. Test edge cases - stale items, parents removals, offline files, different projects, different types
 /** Safely delete several project items in a single undo step.
  * Multi-project aware: groups by owning project, one transaction per project.

--- a/src/api/utils/premierepro-utils.ts
+++ b/src/api/utils/premierepro-utils.ts
@@ -7,6 +7,7 @@ import {
   ProjectItem,
   Sequence,
   VideoTrack,
+  ProjectItemStatic,
 } from "../../types/ppro";
 
 /** Easily run a transaction */
@@ -132,6 +133,7 @@ export const forEachChild = async (
   }
 };
 
+//TODO: TEST EDGE CASES AND MODIFICATIONS OF THE BINS
 /** Loop over each item inside a bin and all its sub-bins */
 export const forEachDescendant = async (
   item: ProjectItem | FolderItem,
@@ -160,8 +162,9 @@ export const deleteItem = async (item: ProjectItem) => {
   );
 };
 
-//TODO: TEST EDGE CASES + PROJECT SWITCHES
-/** Delete many project items in a single undo step (per project) */
+//TODO: TEST EDGE CASES + PROJECT SWITCHES + ITEMS AS PARENTS FOR OTHER ITEMS
+/** Safely delete several project items in a single undo step.
+ * Groups projects itemss by project and removes the groupd as invidual undo step  */
 export const deleteItems = async (items: ProjectItem[]) => {
   // Group items by their owning project so cross-project arrays still work
   const byProject = new Map<string, { proj: Project; actions: Action[] }>();
@@ -185,8 +188,42 @@ export const deleteItems = async (items: ProjectItem[]) => {
   }
 };
 
-// /**
-// ![](data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSc3OTYnIGhlaWdodD0nMjAnPjx0ZXh0IHg9JzYnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzdBNUZGRic+VmlvbGV0PC90ZXh0Pjx0ZXh0IHg9JzU4JyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyMzRjdFOEUnPklyaXM8L3RleHQ+PHRleHQgeD0nOTYnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzREOEEzRSc+Q2FyaWJiZWFuPC90ZXh0Pjx0ZXh0IHg9JzE2OScgeT0nMTQnIGZvbnQtZmFtaWx5PSdtb25vc3BhY2UnIGZvbnQtc2l6ZT0nMTInIGZvbnQtd2VpZ2h0PSdib2xkJyBmaWxsPScjQTg2NEE4Jz5MYXZlbmRlcjwvdGV4dD48dGV4dCB4PScyMzUnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzNFN0U5Nyc+Q2VydWxlYW48L3RleHQ+PHRleHQgeD0nMzAxJyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyM1QzZFMkUnPkZvcmVzdDwvdGV4dD48dGV4dCB4PSczNTMnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0IzM0E0Ric+Um9zZTwvdGV4dD48dGV4dCB4PSczOTEnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0MzNkIyQSc+TWFuZ288L3RleHQ+PHRleHQgeD0nNDM2JyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyM1QzJFQUEnPlB1cnBsZTwvdGV4dD48dGV4dCB4PSc0ODgnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzJFNEZBQSc+Qmx1ZTwvdGV4dD48dGV4dCB4PSc1MjYnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzNFOEE4QSc+VGVhbDwvdGV4dD48dGV4dCB4PSc1NjQnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0EwMzU2QSc+TWFnZW50YTwvdGV4dD48dGV4dCB4PSc2MjMnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0E4OTY3OCc+VGFuPC90ZXh0Pjx0ZXh0IHg9JzY1NCcgeT0nMTQnIGZvbnQtZmFtaWx5PSdtb25vc3BhY2UnIGZvbnQtc2l6ZT0nMTInIGZvbnQtd2VpZ2h0PSdib2xkJyBmaWxsPScjM0U4QTRGJz5HcmVlbjwvdGV4dD48dGV4dCB4PSc2OTknIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzdBNEYyRSc+QnJvd248L3RleHQ+PHRleHQgeD0nNzQ0JyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyNCM0EwM0UnPlllbGxvdzwvdGV4dD48L3N2Zz4=)*/
+/** Find a direct child of a bin or rootItem by name.
+ * Optionally filter by item type. Optionally compare case-insensitively and/or space-insensitively.
+ * **NOTE:** sequences, nests, subclips and multicam sources are all projectItemType of CLIP. Type ROOT is excluded since it never appears as a child.
+ */
+export const getChildByName = async (
+  item: ProjectItem | FolderItem,
+  name: string,
+  caseInsensitive?: boolean,
+  spaceInsensitive?: boolean,
+  projectItemType?: "CLIP" | "BIN" | "COMPOUND" | "FILE" | "STYLE",
+): Promise<ProjectItem | undefined> => {
+  const folder = premierepro.FolderItem.cast(item as ProjectItem);
+  if (!folder) return;
+
+  const type = projectItemType
+    ? premierepro.ProjectItem[`TYPE_${projectItemType}`]
+    : undefined;
+
+  const needNormalize = caseInsensitive || spaceInsensitive;
+  const norm = needNormalize
+    ? (name: string) => {
+        let outName = name;
+        if (caseInsensitive) outName = outName.toLowerCase();
+        if (spaceInsensitive) outName = outName.replace(/\s+/g, "");
+        return outName;
+      }
+    : null;
+  const target = norm ? norm(name) : name;
+
+  const items = await folder.getItems();
+  return items.find(
+    (child) =>
+      (norm ? norm(child.name) : child.name) === target &&
+      (type === undefined || child.type === type),
+  );
+};
 
 // Audio Conversions
 
@@ -195,3 +232,10 @@ export const dbToDec = (x: number) => Math.pow(10, (x - 15) / 20);
 
 /** Convert a linear decimal gain value to dB */
 export const decToDb = (x: number) => 20 * Math.log(x) * Math.LOG10E + 15;
+
+// /**
+// ![](data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSc3OTYnIGhlaWdodD0nMjAnPjx0ZXh0IHg9JzYnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzdBNUZGRic+VmlvbGV0PC90ZXh0Pjx0ZXh0IHg9JzU4JyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyMzRjdFOEUnPklyaXM8L3RleHQ+PHRleHQgeD0nOTYnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzREOEEzRSc+Q2FyaWJiZWFuPC90ZXh0Pjx0ZXh0IHg9JzE2OScgeT0nMTQnIGZvbnQtZmFtaWx5PSdtb25vc3BhY2UnIGZvbnQtc2l6ZT0nMTInIGZvbnQtd2VpZ2h0PSdib2xkJyBmaWxsPScjQTg2NEE4Jz5MYXZlbmRlcjwvdGV4dD48dGV4dCB4PScyMzUnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzNFN0U5Nyc+Q2VydWxlYW48L3RleHQ+PHRleHQgeD0nMzAxJyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyM1QzZFMkUnPkZvcmVzdDwvdGV4dD48dGV4dCB4PSczNTMnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0IzM0E0Ric+Um9zZTwvdGV4dD48dGV4dCB4PSczOTEnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0MzNkIyQSc+TWFuZ288L3RleHQ+PHRleHQgeD0nNDM2JyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyM1QzJFQUEnPlB1cnBsZTwvdGV4dD48dGV4dCB4PSc0ODgnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzJFNEZBQSc+Qmx1ZTwvdGV4dD48dGV4dCB4PSc1MjYnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzNFOEE4QSc+VGVhbDwvdGV4dD48dGV4dCB4PSc1NjQnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0EwMzU2QSc+TWFnZW50YTwvdGV4dD48dGV4dCB4PSc2MjMnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0E4OTY3OCc+VGFuPC90ZXh0Pjx0ZXh0IHg9JzY1NCcgeT0nMTQnIGZvbnQtZmFtaWx5PSdtb25vc3BhY2UnIGZvbnQtc2l6ZT0nMTInIGZvbnQtd2VpZ2h0PSdib2xkJyBmaWxsPScjM0U4QTRGJz5HcmVlbjwvdGV4dD48dGV4dCB4PSc2OTknIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzdBNEYyRSc+QnJvd248L3RleHQ+PHRleHQgeD0nNzQ0JyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyNCM0EwM0UnPlllbGxvdzwvdGV4dD48L3N2Zz4=)*/
+// get/set scale
+// get/set position
+// get/set audioClip Volume By GUID is time varying?
+// get/set audioClip Channel

--- a/src/api/utils/premierepro-utils.ts
+++ b/src/api/utils/premierepro-utils.ts
@@ -390,6 +390,28 @@ export const itemToSequence = async (
   return clipItem.getSequence();
 };
 
+/** Get a project item's duration.
+ *
+ * Synthetic items (adjustment layers, Color Matte, etc.) always return a
+ * `TickTime` of 43200s.
+ */
+export const getItemDuration = async (
+  item: ProjectItem,
+): Promise<TickTime | undefined> => {
+  const clipItem = premierepro.ClipProjectItem.cast(item);
+  if (!clipItem) return;
+
+  if (await clipItem.isSequence()) {
+    const seq = await clipItem.getSequence();
+    return await seq.getEndTime();
+  }
+
+  const media = await clipItem.getMedia();
+  if (!media) return;
+  const dur = await media.duration;
+  return dur;
+};
+
 // Audio Conversions
 
 /** Convert dB to a linear decimal gain value */

--- a/src/api/utils/premierepro-utils.ts
+++ b/src/api/utils/premierepro-utils.ts
@@ -7,7 +7,6 @@ import {
   ProjectItem,
   Sequence,
   VideoTrack,
-  ProjectItemStatic,
 } from "../../types/ppro";
 
 /** Easily run a transaction */
@@ -51,6 +50,7 @@ export const lockedTransaction = async (
   );
 };
 
+//TODO: check for potential bugs - in extendscript were cases tracks indices don't match UI order
 /** Loop over each audio track */
 export const forEachAudioTrack = async (
   sequence: Sequence,
@@ -71,6 +71,7 @@ export const forEachAudioTrack = async (
   }
 };
 
+//TODO: check for potential bugs - in extendscript were cases tracks indices don't match UI order
 /** Loop over each video track */
 export const forEachVideoTrack = async (
   sequence: Sequence,
@@ -133,8 +134,10 @@ export const forEachChild = async (
   }
 };
 
-//TODO: TEST EDGE CASES AND MODIFICATIONS OF THE BINS
-/** Loop over each item inside a bin and all its sub-bins */
+//TODO: add throw guards
+
+//TODO: edge tests. Test cases where callback modifies some descendants
+/** Loop over each item inside a bin and all its sub-bins.  */
 export const forEachDescendant = async (
   item: ProjectItem | FolderItem,
   callback: (child: ProjectItem, depth: number) => void | Promise<void>,
@@ -144,12 +147,16 @@ export const forEachDescendant = async (
   if (!folder) return;
   const items = await folder.getItems();
   for (const child of items) {
-    await callback(child, depth);
-    await forEachDescendant(child, callback, depth + 1);
+    const childFolder = premierepro.FolderItem.cast(child);
+    if (childFolder) {
+      await forEachDescendant(child, callback, depth + 1);
+    } else {
+      await callback(child, depth);
+    }
   }
 };
 
-//TODO: TEST EDGE CASES AND PROJECT ITEM TYPES
+//TODO: test with edge cases and different item types
 /** Delete a project item (bin, sequence, clip) */
 export const deleteItem = async (item: ProjectItem) => {
   const parent = item.getParentBin();
@@ -162,35 +169,50 @@ export const deleteItem = async (item: ProjectItem) => {
   );
 };
 
-//TODO: TEST EDGE CASES + PROJECT SWITCHES + ITEMS AS PARENTS FOR OTHER ITEMS
+//TODO: REVISIT. Implement more optimised approach. Test edge cases - stale items, parents removals, offline files, different projects, different types
 /** Safely delete several project items in a single undo step.
- * Groups projects itemss by project and removes the groupd as invidual undo step  */
+ * Multi-project aware: groups by owning project, one transaction per project.
+ * Parent/child optimization: if an ancestor is also being deleted, the descendant
+ * is skipped - removing the ancestor takes its contents with it*/
 export const deleteItems = async (items: ProjectItem[]) => {
-  // Group items by their owning project so cross-project arrays still work
+  const ids = new Set(items.map((i) => i.getId()));
   const byProject = new Map<string, { proj: Project; actions: Action[] }>();
 
   for (const item of items) {
     const parent = item.getParentBin();
-    if (!parent) continue; // rootItem or detached - skip
+    if (!parent) continue;
+
+    // skip if any ancestor is also in the set
+    let p: FolderItem | null = parent;
+    let coveredByAncestor = false;
+    while (p) {
+      //TODO: remake or add inf loop stopped to avoid freezing for unexpcted 'while' cases
+      const asItem = premierepro.ProjectItem.cast(p);
+      if (!asItem) break;
+      if (ids.has(asItem.getId())) {
+        coveredByAncestor = true;
+        break;
+      }
+      p = asItem.getParentBin();
+    }
+    if (coveredByAncestor) continue;
+
     const proj = await item.getProject();
     const key = proj.guid?.toString?.() ?? String(proj);
     let bucket = byProject.get(key);
-    if (!bucket) {
-      bucket = { proj, actions: [] };
-      byProject.set(key, bucket);
-    }
+    if (!bucket) byProject.set(key, (bucket = { proj, actions: [] }));
     bucket.actions.push(parent.createRemoveItemAction(item));
   }
 
   for (const { proj, actions } of byProject.values()) {
-    if (actions.length === 0) continue;
-    await asTransaction(proj, actions, "Delete Items");
+    if (actions.length) await asTransaction(proj, actions, "Delete Items");
   }
 };
 
+//TODO? extend or create separate function to abstract futher with friendlier types — e.g. SEQUENCE, MULTICAM_SOURCE, SUBCLIP, NEST, AUDIO, MEDIA, MOGRT
 /** Find a direct child of a bin or rootItem by name.
  * Optionally filter by item type. Optionally compare case-insensitively and/or space-insensitively.
- * **NOTE:** sequences, nests, subclips and multicam sources are all projectItemType of CLIP. Type ROOT is excluded since it never appears as a child.
+ * **NOTE:** sequences, nests, subclips and multicam sources are all type of CLIP. Type ROOT is excluded since it never appears as a child.
  */
 export const getChildByName = async (
   item: ProjectItem | FolderItem,
@@ -232,10 +254,3 @@ export const dbToDec = (x: number) => Math.pow(10, (x - 15) / 20);
 
 /** Convert a linear decimal gain value to dB */
 export const decToDb = (x: number) => 20 * Math.log(x) * Math.LOG10E + 15;
-
-// /**
-// ![](data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSc3OTYnIGhlaWdodD0nMjAnPjx0ZXh0IHg9JzYnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzdBNUZGRic+VmlvbGV0PC90ZXh0Pjx0ZXh0IHg9JzU4JyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyMzRjdFOEUnPklyaXM8L3RleHQ+PHRleHQgeD0nOTYnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzREOEEzRSc+Q2FyaWJiZWFuPC90ZXh0Pjx0ZXh0IHg9JzE2OScgeT0nMTQnIGZvbnQtZmFtaWx5PSdtb25vc3BhY2UnIGZvbnQtc2l6ZT0nMTInIGZvbnQtd2VpZ2h0PSdib2xkJyBmaWxsPScjQTg2NEE4Jz5MYXZlbmRlcjwvdGV4dD48dGV4dCB4PScyMzUnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzNFN0U5Nyc+Q2VydWxlYW48L3RleHQ+PHRleHQgeD0nMzAxJyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyM1QzZFMkUnPkZvcmVzdDwvdGV4dD48dGV4dCB4PSczNTMnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0IzM0E0Ric+Um9zZTwvdGV4dD48dGV4dCB4PSczOTEnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0MzNkIyQSc+TWFuZ288L3RleHQ+PHRleHQgeD0nNDM2JyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyM1QzJFQUEnPlB1cnBsZTwvdGV4dD48dGV4dCB4PSc0ODgnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzJFNEZBQSc+Qmx1ZTwvdGV4dD48dGV4dCB4PSc1MjYnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzNFOEE4QSc+VGVhbDwvdGV4dD48dGV4dCB4PSc1NjQnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0EwMzU2QSc+TWFnZW50YTwvdGV4dD48dGV4dCB4PSc2MjMnIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nI0E4OTY3OCc+VGFuPC90ZXh0Pjx0ZXh0IHg9JzY1NCcgeT0nMTQnIGZvbnQtZmFtaWx5PSdtb25vc3BhY2UnIGZvbnQtc2l6ZT0nMTInIGZvbnQtd2VpZ2h0PSdib2xkJyBmaWxsPScjM0U4QTRGJz5HcmVlbjwvdGV4dD48dGV4dCB4PSc2OTknIHk9JzE0JyBmb250LWZhbWlseT0nbW9ub3NwYWNlJyBmb250LXNpemU9JzEyJyBmb250LXdlaWdodD0nYm9sZCcgZmlsbD0nIzdBNEYyRSc+QnJvd248L3RleHQ+PHRleHQgeD0nNzQ0JyB5PScxNCcgZm9udC1mYW1pbHk9J21vbm9zcGFjZScgZm9udC1zaXplPScxMicgZm9udC13ZWlnaHQ9J2JvbGQnIGZpbGw9JyNCM0EwM0UnPlllbGxvdzwvdGV4dD48L3N2Zz4=)*/
-// get/set scale
-// get/set position
-// get/set audioClip Volume By GUID is time varying?
-// get/set audioClip Channel

--- a/src/api/utils/premierepro-utils.ts
+++ b/src/api/utils/premierepro-utils.ts
@@ -247,6 +247,55 @@ export const getChildByName = async (
   );
 };
 
+/** Find a direct child of a bin or rootItem by id. */
+export const getChildById = async (
+  id: string,
+  item: ProjectItem | FolderItem,
+): Promise<ProjectItem | undefined> => {
+  const folder = premierepro.FolderItem.cast(item as ProjectItem);
+  if (!folder) return;
+  const items = await folder.getItems();
+  return items.find((child) => child.getId() === id);
+};
+
+/** Recursively find a descendant of a bin or rootItem by id. */
+export const getDescendantById = async (
+  id: string,
+  item: ProjectItem | FolderItem,
+): Promise<ProjectItem | undefined> => {
+  const folder = premierepro.FolderItem.cast(item as ProjectItem);
+  if (!folder) return;
+
+  const items = await folder.getItems();
+  for (const child of items) {
+    if (child.getId() === id) return child;
+    const childFolder = premierepro.FolderItem.cast(child);
+    if (childFolder) {
+      const found = await getDescendantById(id, child);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+/** Recursively find an item by id.
+ * Optionally set `startFrom` to a Project or bin to scope. Defaults to active project. */
+export const getItemById = async (
+  id: string,
+  startFrom?: ProjectItem | FolderItem | Project,
+): Promise<ProjectItem | undefined> => {
+  // distinguish Project from bin by `getRootItem` property
+  if (startFrom && "getRootItem" in startFrom) {
+    const root = await startFrom.getRootItem();
+    return getDescendantById(id, root);
+  }
+  if (startFrom) return getDescendantById(id, startFrom);
+  const proj = await premierepro.Project.getActiveProject();
+  if (!proj) return;
+  const root = await proj.getRootItem();
+  return getDescendantById(id, root);
+};
+
 // Audio Conversions
 
 /** Convert dB to a linear decimal gain value */

--- a/src/api/utils/premierepro-utils.ts
+++ b/src/api/utils/premierepro-utils.ts
@@ -13,6 +13,7 @@ import {
   ClipProjectItem,
   FrameRate,
   Metadata,
+  TickTime,
 } from "../../types/ppro";
 
 /**
@@ -409,6 +410,108 @@ export const getFrameRate = async (
   return fps ? premierepro.FrameRate.createWithValue(fps) : undefined;
 };
 
+/** Get the duration of a single frame as a TickTime at the given frame rate. */
+export const getFrameDuration = (frameRate: FrameRate): TickTime =>
+  premierepro.TickTime.createWithFrameAndFrameRate(1, frameRate);
+
+/** Convert a TickTime to a frame count at the given frame rate */
+export const timeToFrames = (time: TickTime, frameRate: FrameRate): number =>
+  time.ticksNumber / frameRate.ticksPerFrame;
+
+/**
+ * Parse a timecode string ("HH:MM:SS:FF" or "HH;MM;SS;FF") into a TickTime.
+ */
+export const timecodeToTime = (
+  timecode: string,
+  frameRate: FrameRate,
+): TickTime => {
+  const dropFrame = timecode.indexOf(";") > -1;
+  const [h, m, s, f] = timecode.split(/[:;]/).map((p) => parseInt(p, 10));
+  const fpsRound = Math.round(frameRate.value);
+
+  let totalFrames = h * 3600 * fpsRound + m * 60 * fpsRound + s * fpsRound + f;
+
+  if (dropFrame) {
+    const dropPerMin = Math.round(frameRate.value * 0.066666); // skip 2 frames per minute at 29.97, 4 at 59.94
+    const totalMinutes = h * 60 + m;
+    totalFrames -= dropPerMin * (totalMinutes - Math.floor(totalMinutes / 10));
+  }
+
+  return premierepro.TickTime.createWithFrameAndFrameRate(
+    totalFrames,
+    frameRate,
+  );
+};
+
+/**
+ * Format a TickTime as a Premiere timecode string.
+ *
+ * Pass `dropFrame: true` to produce SMPTE drop-frame ("HH;MM;SS;FF"),
+ * which is what Premiere shows on 29.97 / 59.94 timelines so displayed
+ * timecode tracks wall-clock time. Default is non-drop ("HH:MM:SS:FF").
+ */
+export const timeToTimecode = (
+  time: TickTime,
+  frameRate: FrameRate,
+  dropFrame = false,
+): string => {
+  const fpsRound = Math.round(frameRate.value);
+  const realFrames = Math.round(time.ticksNumber / frameRate.ticksPerFrame);
+
+  let labelFrames = realFrames;
+  if (dropFrame) {
+    const dropPerMin = Math.round(frameRate.value * 0.066666); // 2 @ 29.97, 4 @ 59.94
+    const framesPer10Min = Math.round(frameRate.value * 60 * 10);
+    const framesPerMin = fpsRound * 60 - dropPerMin;
+    const tenMinBlocks = Math.floor(realFrames / framesPer10Min);
+    const remainder = realFrames % framesPer10Min;
+    const skippedInBlocks = dropPerMin * 9 * tenMinBlocks;
+    const skippedInRemainder =
+      remainder > dropPerMin
+        ? dropPerMin * Math.floor((remainder - dropPerMin) / framesPerMin)
+        : 0;
+    labelFrames = realFrames + skippedInBlocks + skippedInRemainder;
+  }
+
+  const f = labelFrames % fpsRound;
+  const totalSec = Math.floor(labelFrames / fpsRound);
+  const s = totalSec % 60;
+  const m = Math.floor(totalSec / 60) % 60;
+  const h = Math.floor(totalSec / 3600);
+
+  const pad = (x: number) => x.toString().padStart(2, "0");
+  const sep = dropFrame ? ";" : ":";
+  return `${pad(h)}${sep}${pad(m)}${sep}${pad(s)}${sep}${pad(f)}`;
+};
+
+/** Check is the sequence displays drop-frame timecode ("HH;MM;SS;FF") */
+export const isSequenceDropFrame = async (
+  sequence: Sequence,
+): Promise<boolean> => {
+  const display = await (await sequence.getSettings()).getVideoDisplayFormat();
+  return display.type === 102 || display.type === 106; //102 = 29.97, 106 = 59.94 (both drop-frame)
+};
+
+/**Format a TickTime as the timecode that the given sequence would display*/
+export const getTimecodeFromSequence = async (
+  time: TickTime,
+  sequence: Sequence,
+): Promise<string> => {
+  const settings = await sequence.getSettings();
+  const frameRate = settings.getVideoFrameRate();
+  const dropFrame = await isSequenceDropFrame(sequence);
+  return timeToTimecode(time, frameRate, dropFrame);
+};
+
+/** Get the sequence length in frames. */
+export const getSequenceLengthInFrames = async (
+  sequence: Sequence,
+): Promise<number> => {
+  const end = await sequence.getEndTime();
+  const fps = (await sequence.getSettings()).getVideoFrameRate();
+  return timeToFrames(end, fps);
+};
+
 //Metadata helpers
 const PPRO_META_URI = "http://ns.adobe.com/premierePrivateProjectMetaData/1.0/";
 
@@ -460,10 +563,6 @@ export const listPrMetadataKeys = async (
   }
   return keys;
 };
-
-//todo
-// setPrMetadata
-// removePrMetadata
 
 // Audio Conversions
 


### PR DESCRIPTION
Migrating Bolt CEP helpers to UXP. WIP - pushing as I go

Did initial test setup + deep UXP api exploration. Now mid-migration, heavily testing against the runtime  Migrated
- forEachChild
- deleteItem - no more .bin method! 
- getChildByName - now takes optional  type of "CLIP" | "BIN" | "COMPOUND" | "FILE" | "STYLE". Added flags to ignore spaces and cases
- Drafted some new features for old function as well
- Time methods now are part of TickTime type, no need to migrate

New
- forEachDescendant - recursive walk, runs the callback on every non-bin descendant (descends into bins instead of invoking the callback on them)
- deleteItems - batch delete in a single undo, multi-project aware, with parent/child optimization (still testing)